### PR TITLE
Sync panic_fmt signature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,12 @@ extern {
 
 #[cfg(not(feature="std"))]
 #[lang = "panic_fmt"]
-pub fn panic_fmt(fmt: core::fmt::Arguments, _file_line: &(&'static str, u32)) -> !
-{
+pub fn panic_fmt(
+	fmt: core::fmt::Arguments,
+	_file: &'static str,
+	_line: u32,
+	_col: u32,
+) -> ! {
     let message = format!("{}", fmt);
     unsafe { panic(message.as_ptr(), message.len() as u32) }
     unreachable!("panic MUST return Err(UserTrap); interpreter will stop execution when Err is returned; qed")


### PR DESCRIPTION
`panic_fmt` signature have changed some time ago. This PR syncs the signature with the [latest one](https://github.com/rust-lang/rust/blob/525b81d570b15df2ed5896f0215baea5c64c650c/src/libcore/panicking.rs#L68).