### PR TITLE
Clean wrapped

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,6 @@ mod panic;
 pub use wrapped::{WrappedArgs, WrappedResult, parse_args};
 pub use crypto::keccak;
 
-unsafe fn read_ptr_mut(slc: &[u8]) -> *mut u8 {
-	read_u32(slc) as *const u8 as *mut u8
-}
-
 pub fn read_u32(slc: &[u8]) -> u32 {
 	LittleEndian::read_u32(slc)
 }

--- a/src/wrapped.rs
+++ b/src/wrapped.rs
@@ -1,13 +1,23 @@
 use core::{slice, mem, ops};
-use {Vec, read_u32, read_ptr_mut, write_u32, write_ptr};
+use {Vec};
+
+#[repr(C)]
+struct Descriptor {
+	args_ptr: *const u8,
+	args_len: usize,
+	result_ptr: *const u8,
+	result_len: usize,
+}
 
 pub struct WrappedArgs {
-	inner: Vec<u8>,
+	desc: *const Descriptor
 }
 
 impl AsRef<[u8]> for WrappedArgs {
 	fn as_ref(&self) -> &[u8] {
-		&self.inner
+		unsafe {
+			slice::from_raw_parts((*self.desc).args_ptr, (*self.desc).args_len)
+		}
 	}
 }
 
@@ -15,51 +25,33 @@ impl ops::Deref for WrappedArgs {
 	type Target = [u8];
 
     fn deref(&self) -> &Self::Target {
-		&self.inner
-	}
-}
-
-impl WrappedArgs {
-	unsafe fn from_raw(ptr: *mut u8, len: u32) -> Self {
-		WrappedArgs {
-			inner: Vec::from_raw_parts(ptr, len as usize, len as usize),
+		unsafe {
+			slice::from_raw_parts((*self.desc).args_ptr, (*self.desc).args_len)
 		}
-	}
-}
-
-impl Drop for WrappedArgs {
-	fn drop(&mut self) {
-		mem::forget(mem::replace(&mut self.inner, Vec::new()))
 	}
 }
 
 pub struct WrappedResult {
-	inner: *mut u8,
+	desc: *mut Descriptor
 }
 
 impl WrappedResult {
 	pub fn done(self, val: Vec<u8>) {
-		if val.len() > 0 {
-			let dst = unsafe { slice::from_raw_parts_mut(self.inner, 2 * 4) };
-
-			write_ptr(&mut dst[0..4], val.as_ptr() as *mut _);
-			write_u32(&mut dst[4..8], val.len() as u32);
-			// managed in calling code
-			mem::forget(val);
+		unsafe {
+			if !val.is_empty() {
+				(*self.desc).result_ptr = val.as_ptr();
+				(*self.desc).result_len = val.len();
+			} else {
+				(*self.desc).result_len = 0;
+			}
 		}
+		mem::forget(val);
 	}
 }
 
 pub unsafe fn parse_args(ptr: *mut u8) -> (WrappedArgs, WrappedResult) {
-	let desc_slice = slice::from_raw_parts(ptr, 4 * 4);
-
-	let input_ptr = read_ptr_mut(&desc_slice[0..4]);
-	let input_len = read_u32(&desc_slice[4..8]);
-
-	let result_ptr = ptr.offset(8);
-
-	(
-		WrappedArgs::from_raw(input_ptr, input_len),
-		WrappedResult { inner: result_ptr }
-	)
+	let desc = ptr as *mut Descriptor;
+	let args = WrappedArgs { desc: desc };
+	let result = WrappedResult { desc: desc };
+	(args, result)
 }


### PR DESCRIPTION
- Declare `Descriptor` struct. It makes layout of `Descriptor` more legible.
- unconditionally initialize `desc.result_len = 0;` if result is empty.