### PR TITLE
Force panic_fmt to be overriden

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,6 +63,9 @@ mod crypto;
 
 mod panic;
 
+#[cfg(not(feature="std"))]
+pub use panic::panic_fmt;
+
 pub use wrapped::{WrappedArgs, WrappedResult, parse_args};
 pub use crypto::keccak;
 

--- a/src/panic.rs
+++ b/src/panic.rs
@@ -3,8 +3,10 @@
 use Vec;
 use byteorder::{LittleEndian, ByteOrder};
 
+/// Overrides the default panic_fmt
+#[no_mangle]
 #[lang = "panic_fmt"]
-pub fn panic_fmt(_fmt: ::core::fmt::Arguments, file: &'static str, line: u32, col: u32) -> ! {
+pub extern fn panic_fmt(_fmt: ::core::fmt::Arguments, file: &'static str, line: u32, col: u32) -> ! {
 	extern "C" {
 		fn panic(payload_ptr: *const u8, payload_len: u32) -> !;
 	}


### PR DESCRIPTION
extern and #[no_mangle] attribute added to panic_fmt