### PR TITLE
Remove unwanted conditional compilation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ exclude = [ "demo/*" ]
 pwasm-alloc = { path = "alloc", version = "0.4" }
 pwasm-libc = { path = "libc", version = "0.2" }
 tiny-keccak = "1"
-cfg-if = "0.1"
 
 [dependencies.byteorder]
 version = "1"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,19 +20,10 @@ extern crate pwasm_alloc;
 #[cfg(not(feature="std"))]
 extern crate pwasm_libc;
 
+#[allow(unused)]
 #[macro_use]
-extern crate cfg_if;
-
-cfg_if! {
-	if #[cfg(all(feature="panic_with_msg", not(feature="std")))] {
-		#[macro_use]
-		extern crate alloc;
-		pub use alloc::{vec, format};
-	} else {
-		extern crate alloc;
-		pub use alloc::{vec, format};
-	}
-}
+extern crate alloc;
+pub use alloc::{vec, format};
 
 extern crate byteorder;
 


### PR DESCRIPTION
Currently there is a code that conditionally enables macro on `extern crate alloc`. But tooling doesn't really work nice with conditionally exported functions, RLS and IntelliJ rust just goes crazy when they see it:

![image](https://user-images.githubusercontent.com/11201122/42408298-2b6121cc-81d3-11e8-8657-22feff89114f.png)

There is multiple PRs and issues without any progress, eg [this](https://github.com/intellij-rust/intellij-rust/pull/2166), [this](https://github.com/intellij-rust/intellij-rust/issues/1191) and [this](https://github.com/intellij-rust/intellij-rust/issues/461).

I propose to just allow unused macros to be imported. It allows treat all targets in the same manner. Now we already have complicated condition where we want to import macro and where we don't.
```rust
if #[cfg(all(feature="panic_with_msg", not(feature="std")))] {
```