### PR TITLE
Replace parity-hash with fixed-hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,20 +13,14 @@ categories = ["no-std", "embedded"]
 exclude = [ "demo/*" ]
 
 [dependencies]
+fixed-hash = { version = "0.2", default-features = false }
+byteorder = { version = "1", default-features = false }
 pwasm-alloc = { path = "alloc", version = "0.4" }
 pwasm-libc = { path = "libc", version = "0.2" }
 tiny-keccak = "1"
 
-[dependencies.byteorder]
-version = "1"
-default-features = false
-
-[dependencies.parity-hash]
-version = "1"
-default-features = false
-
 [features]
 default = []
-std = ["parity-hash/std"]
+std = ["fixed-hash/std"]
 strict = ["pwasm-libc/strict", "pwasm-alloc/strict"]
 panic_with_msg = []

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,25 +1,28 @@
 use tiny_keccak::Keccak;
-use hash::H256;
+use types::H256;
 
 /// Compute keccak hash.
 ///
 /// # Examples
 ///
 /// ```rust
-/// use pwasm_std::keccak;
+/// use pwasm_std::{keccak, types};
 ///
-/// let hash = keccak("hello world");
+/// let hash = keccak("hello world".as_bytes());
 ///
-/// let expected = &[
-/// 	71, 23, 50, 133, 168, 215, 52, 30,
+/// let expected = types::H256::from([
+/// 	71_u8, 23, 50, 133, 168, 215, 52, 30,
 /// 	94, 151, 47, 198, 119, 40, 99, 132,
 /// 	248, 2, 248, 239, 66, 165, 236, 95,
 /// 	3, 187, 250, 37, 76, 176, 31, 173
-/// ];
+/// ]);
 ///
-/// assert_eq!(hash.as_ref(), expected);
+/// assert_eq!(hash, expected);
 /// ```
-pub fn keccak<T>(input: T) -> H256 where T: AsRef<[u8]> {
+pub fn keccak<T>(input: T) -> H256
+where
+	T: AsRef<[u8]>
+{
 	let mut keccak = Keccak::new_keccak256();
 	let mut res = H256::new();
 	keccak.update(input.as_ref());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,7 +27,9 @@ pub use alloc::{vec, format};
 
 extern crate byteorder;
 
-pub extern crate parity_hash;
+#[macro_use]
+extern crate fixed_hash;
+
 extern crate tiny_keccak;
 
 use byteorder::{LittleEndian, ByteOrder};
@@ -36,7 +38,8 @@ pub use alloc::boxed::Box;
 pub use alloc::string::String;
 pub use alloc::str;
 pub use alloc::vec::Vec;
-pub use parity_hash as hash;
+
+pub mod types;
 
 // Safe wrapper around debug logging
 pub mod logger;

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,20 @@
+//! Provides primitive fixed size hash types.
+
+// Constructed via `fixed_hash` macro.
+
+construct_hash!(H32, 4);
+construct_hash!(H64, 8);
+construct_hash!(H128, 16);
+construct_hash!(H160, 20);
+construct_hash!(H256, 32);
+construct_hash!(H264, 33);
+construct_hash!(H512, 64);
+construct_hash!(H1024, 128);
+construct_hash!(H2048, 256);
+
+/// Represents an address in ethereum context.
+/// 
+/// # Note
+/// 
+/// Addresses have 160 bytes length.
+pub type Address = H160;


### PR DESCRIPTION
tl;dr: This PR is the first in a series to clean up the dependency tree of `pwasm-*`.

After a long time finding out which dependencies are deprecated, old, new, replaced etc. I think I am now confident to say that `parity-hash` should be replaced by its successor `fixed-hash`. Since the interface of `fixed-hash` is reduced to be minimal and be comparable to the one provided by `uint` `pwasm-std` has to provide its own hash types now. However, fortunately this isn't a big deal.

I had to rewrite a doc comment test case but now everything works again.
I would recommend releasing a new major version update since the changes from `parity-hash` to `fixed-hash` might break things.